### PR TITLE
Allocate.sh

### DIFF
--- a/Allocate
+++ b/Allocate
@@ -13,21 +13,21 @@ sudo cp docker-compose.yaml .env /dir3
 
 echo "The script executed successfully"
 echo 
-echo "copy nodes,clef and password to the corresponding folder"
+echo "copy folder1,folder2 and folder3 to the corresponding folder"
 
 cd /
 cd dir1 || exit
 
 for ((i=num1; i<=num2; i++))
 do
-sudo cp -r bee-$i /dir2
+sudo cp -r folder1-$i /dir2
 done
-sudo cp -r clef password /dir2
+sudo cp -r folder2 folder3 /dir2
 
 for ((j=num3; j<=num4; j++))
 do
-sudo cp -r bee-$j /dir3
+sudo cp -r folder1-$j /dir3
 done
-sudo cp -r clef password /dir3
+sudo cp -r folder2 folder3 /dir3
 
 echo "The script executed successfully"

--- a/Allocate
+++ b/Allocate
@@ -1,0 +1,33 @@
+# This allocate.sh is designed to help us assign different folders and their subfiles (folders) to different directories
+
+
+#!/bin/bash
+
+echo "copy docker-compose.yaml and .env to dir1&dir2&dir3"
+
+cd dir || exit  # 'dir' is the directory where the docker-compose.yaml and .env to be copied is located
+
+sudo cp docker-compose.yaml .env /dir1
+sudo cp docker-compose.yaml .env /dir2
+sudo cp docker-compose.yaml .env /dir3
+
+echo "The script executed successfully"
+echo 
+echo "copy nodes,clef and password to the corresponding folder"
+
+cd /
+cd dir1 || exit
+
+for ((i=num1; i<=num2; i++))
+do
+sudo cp -r bee-$i /dir2
+done
+sudo cp -r clef password /dir2
+
+for ((j=num3; j<=num4; j++))
+do
+sudo cp -r bee-$j /dir3
+done
+sudo cp -r clef password /dir3
+
+echo "The script executed successfully"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,1 @@
-You can execute this script by two steps:
-
-First, you need upload this shell script to the destination dir and cd to this dir
-
-Second, use "sudo bash allocate.sh" to execute this script
+Design for allocating any folders or files on your pc

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
-# Shell-Scripts-for-Linux
-Some scripts for Linux O&amp;M
+You can execute this script by two steps:
 
+First, you need upload this shell script to the destination dir and cd to this dir
+
+Second, use "sudo bash allocate.sh" to execute this script


### PR DESCRIPTION
### Allocate.sh is designed to help us assign different folders and their subfiles (folders) to different directories.

You can use this script by two steps:

1. you should upload this script to the destination folder **_dir_** and cd to this folder **_dir_**.
2. you can use 'sudo bash Allocate.sh' to execute this script.